### PR TITLE
turn off building of shared libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,12 +101,12 @@ endif(CURLPP_BUILD_SHARED_LIBS)
 #  (solution taken from https://cmake.org/Wiki/CMake_FAQ#How_do_I_make_my_shared_and_static_libraries_have_the_same_root_name.2C_but_different_suffixes.3F)
 # 
 # Making shared and static libraries have the same root name, but different suffixes
-SET_TARGET_PROPERTIES(${PROJECT_NAME}_static PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
+#SET_TARGET_PROPERTIES(${PROJECT_NAME}_static PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
 # Now the library target "curlpp_static" will be named "curlpp.lib" with MS tools.
 # This conflicts with the "curlpp.lib" import library corresponding to "curlpp.dll",
 # so we add a "lib" prefix (which is default on other platforms anyway):
-SET_TARGET_PROPERTIES(${PROJECT_NAME}_static PROPERTIES PREFIX "lib")
-target_link_libraries(${PROJECT_NAME}_static ${CURL_LIBRARIES} ${CONAN_LIBS})
+#SET_TARGET_PROPERTIES(${PROJECT_NAME}_static PROPERTIES PREFIX "lib")
+#target_link_libraries(${PROJECT_NAME}_static ${CURL_LIBRARIES} ${CONAN_LIBS})
 
 # install headers
 install(DIRECTORY include/utilspp/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/utilspp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,13 +87,12 @@ file(GLOB_RECURSE SourceFileList "${CMAKE_CURRENT_SOURCE_DIR}/src/*")
 option(CURLPP_BUILD_SHARED_LIBS "Build shared libraries" OFF)
 if(CURLPP_BUILD_SHARED_LIBS)
   add_library(${PROJECT_NAME} SHARED ${HeaderFileList} ${SourceFileList})
-  target_link_libraries(${PROJECT_NAME} ${CURL_LIBRARIES} ${CONAN_LIBS})
-  set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 1 VERSION 1.0.0)
 else()
-  add_library(${PROJECT_NAME}_static STATIC ${HeaderFileList} ${SourceFileList})
-  target_link_libraries(${PROJECT_NAME}_static ${CURL_LIBRARIES} ${CONAN_LIBS})
-  set_target_properties(${PROJECT_NAME}_static PROPERTIES SOVERSION 1 VERSION 1.0.0)
-endif(CURLPP_BUILD_SHARED_LIBS)
+  add_library(${PROJECT_NAME} STATIC ${HeaderFileList} ${SourceFileList})
+endif()
+
+target_link_libraries(${PROJECT_NAME} ${CURL_LIBRARIES} ${CONAN_LIBS})
+set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 1 VERSION 1.0.0)
 
 # Make sure that on unix-platforms shared and static libraries have
 # the same root name, but different suffixes.
@@ -112,14 +111,7 @@ endif(CURLPP_BUILD_SHARED_LIBS)
 install(DIRECTORY include/utilspp/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/utilspp")
 install(DIRECTORY include/curlpp/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/curlpp")
 
-if(CURLPP_BUILD_SHARED_LIBS)
 install(TARGETS ${PROJECT_NAME}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-else()
-install(TARGETS ${PROJECT_NAME}_static
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-endif(CURLPP_BUILD_SHARED_LIBS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,11 +83,17 @@ endif()
 
 file(GLOB_RECURSE HeaderFileList "${CMAKE_CURRENT_SOURCE_DIR}/include/*")
 file(GLOB_RECURSE SourceFileList "${CMAKE_CURRENT_SOURCE_DIR}/src/*")
-add_library(${PROJECT_NAME} SHARED ${HeaderFileList} ${SourceFileList})
-target_link_libraries(${PROJECT_NAME} ${CURL_LIBRARIES} ${CONAN_LIBS})
-set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 1 VERSION 1.0.0)
 
-add_library(${PROJECT_NAME}_static STATIC ${HeaderFileList} ${SourceFileList})
+option(CURLPP_BUILD_SHARED_LIBS "Build shared libraries" OFF)
+if(CURLPP_BUILD_SHARED_LIBS)
+  add_library(${PROJECT_NAME} SHARED ${HeaderFileList} ${SourceFileList})
+  target_link_libraries(${PROJECT_NAME} ${CURL_LIBRARIES} ${CONAN_LIBS})
+  set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 1 VERSION 1.0.0)
+else()
+  add_library(${PROJECT_NAME}_static STATIC ${HeaderFileList} ${SourceFileList})
+  target_link_libraries(${PROJECT_NAME}_static ${CURL_LIBRARIES} ${CONAN_LIBS})
+  set_target_properties(${PROJECT_NAME}_static PROPERTIES SOVERSION 1 VERSION 1.0.0)
+endif(CURLPP_BUILD_SHARED_LIBS)
 
 # Make sure that on unix-platforms shared and static libraries have
 # the same root name, but different suffixes.
@@ -106,8 +112,14 @@ target_link_libraries(${PROJECT_NAME}_static ${CURL_LIBRARIES} ${CONAN_LIBS})
 install(DIRECTORY include/utilspp/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/utilspp")
 install(DIRECTORY include/curlpp/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/curlpp")
 
-install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_static
+if(CURLPP_BUILD_SHARED_LIBS)
+install(TARGETS ${PROJECT_NAME}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-
+else()
+install(TARGETS ${PROJECT_NAME}_static
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif(CURLPP_BUILD_SHARED_LIBS)

--- a/src/curlpp/OptionBase.cpp
+++ b/src/curlpp/OptionBase.cpp
@@ -26,10 +26,10 @@
 
 curlpp::OptionBase::OptionBase(CURLoption option)
   : mOption(option)
-{};
+{}
 
 curlpp::OptionBase::~OptionBase()
-{};
+{}
 
 bool curlpp::OptionBase::operator<(const curlpp::OptionBase & rhs) const 
 {

--- a/src/curlpp/internal/OptionSetter.cpp
+++ b/src/curlpp/internal/OptionSetter.cpp
@@ -42,7 +42,7 @@ struct Callbacks
 	WriteCallback(char * buffer, size_t size, size_t nitems, internal::CurlHandle * handle)
 	{
 		return handle->executeWriteFunctor(buffer, size, nitems);
-	};
+	}
 
 
 	static size_t
@@ -54,21 +54,21 @@ struct Callbacks
 			realwrote = 0;
 
 		return realwrote;
-	};
+	}
 
 
 	static size_t
 	HeaderCallback(char * buffer, size_t size, size_t nitems, internal::CurlHandle * handle)
 	{
 		return handle->executeHeaderFunctor(buffer, size, nitems);
-	};
+	}
 
 
 	static size_t
 	ReadCallback(char * buffer, size_t size, size_t nitems, internal::CurlHandle * handle)
 	{
 		return handle->executeReadFunctor(buffer, size, nitems);
-	};
+	}
 
 
 	static size_t
@@ -80,7 +80,7 @@ struct Callbacks
 			realread = CURL_READFUNC_ABORT;
 
 		return realread;
-	};
+	}
 
 
 	static int
@@ -91,7 +91,7 @@ struct Callbacks
 											double ulnow)
 	{
 		return handle->executeProgressFunctor(dltotal, dlnow, ultotal, ulnow);
-	};
+	}
 
 
 	static int
@@ -102,7 +102,7 @@ struct Callbacks
 									internal::CurlHandle * handle)
 	{
 		return handle->executeDebugFunctor(type, data, size);
-	};
+	}
 
 
 	static CURLcode 
@@ -111,16 +111,16 @@ struct Callbacks
 										internal::CurlHandle * handle)
 	{
 		return handle->executeSslCtxFunctor(ssl_ctx);
-	};
+	}
 
-};
+}
 
 
 void OptionSetter<curlpp::Forms, CURLOPT_HTTPPOST>
 ::setOpt(internal::CurlHandle * handle, ParamType value)
 {
 	handle->option(CURLOPT_HTTPPOST, value.cHttpPost());
-};
+}
 
 
 void OptionSetter<curlpp::types::WriteFunctionFunctor, CURLOPT_WRITEFUNCTION>
@@ -129,7 +129,7 @@ void OptionSetter<curlpp::types::WriteFunctionFunctor, CURLOPT_WRITEFUNCTION>
 	handle->option(CURLOPT_WRITEFUNCTION, Callbacks::WriteCallback);
 	handle->option(CURLOPT_WRITEDATA, handle);
 	handle->setWriteFunctor(value);
-};
+}
 
 
 #ifdef HAVE_BOOST
@@ -141,7 +141,7 @@ void OptionSetter<curlpp::types::BoostWriteFunction, CURLOPT_WRITEFUNCTION>
 	handle->option(CURLOPT_WRITEDATA, handle);
 	handle->setWriteFunctor(curlpp::types::WriteFunctionFunctor(&value,
 		&curlpp::types::BoostWriteFunction::operator()));
-};
+}
 
 #endif
 
@@ -151,7 +151,7 @@ void OptionSetter<FILE *, CURLOPT_WRITEDATA>
 {
 	handle->option(CURLOPT_WRITEFUNCTION, (void *)NULL);
 	handle->option(CURLOPT_WRITEDATA, value);
-};
+}
 
 
 void OptionSetter<std::ostream *, CURLOPT_WRITEDATA>
@@ -159,7 +159,7 @@ void OptionSetter<std::ostream *, CURLOPT_WRITEDATA>
 {
 	handle->option(CURLOPT_WRITEFUNCTION, (void *)Callbacks::StreamWriteCallback);
 	handle->option(CURLOPT_WRITEDATA, value);
-};
+}
 
 
 void OptionSetter<curlpp::types::ReadFunctionFunctor, CURLOPT_READFUNCTION>
@@ -168,7 +168,7 @@ void OptionSetter<curlpp::types::ReadFunctionFunctor, CURLOPT_READFUNCTION>
 	handle->option(CURLOPT_READFUNCTION, Callbacks::ReadCallback);
 	handle->option(CURLOPT_READDATA, handle);
 	handle->setReadFunctor(value);
-};
+}
 
 
 #ifdef HAVE_BOOST
@@ -179,7 +179,7 @@ void OptionSetter<curlpp::types::BoostReadFunction, CURLOPT_READFUNCTION>
 	handle->option(CURLOPT_READFUNCTION, Callbacks::ReadCallback);
 	handle->option(CURLOPT_READDATA, handle);
 	handle->setReadFunctor(value);
-};
+}
 
 #endif
 
@@ -189,7 +189,7 @@ void OptionSetter<FILE *, CURLOPT_READDATA>
 {
 	handle->option(CURLOPT_READFUNCTION, (void *)NULL);
 	handle->option(CURLOPT_READDATA, value);
-};
+}
 
 
 
@@ -198,7 +198,7 @@ void OptionSetter<std::istream *, CURLOPT_READDATA>
 {
 	handle->option(CURLOPT_READFUNCTION, (void *)Callbacks::StreamReadCallback);
 	handle->option(CURLOPT_READDATA, value);
-};
+}
 
 
 void OptionSetter<curlpp::types::ProgressFunctionFunctor, CURLOPT_PROGRESSFUNCTION>
@@ -207,7 +207,7 @@ void OptionSetter<curlpp::types::ProgressFunctionFunctor, CURLOPT_PROGRESSFUNCTI
 	handle->option(CURLOPT_PROGRESSFUNCTION, Callbacks::ProgressCallback);
 	handle->option(CURLOPT_PROGRESSDATA, handle);
 	handle->setProgressFunctor(value);
-};
+}
 
 
 #ifdef HAVE_BOOST
@@ -218,7 +218,7 @@ void OptionSetter<curlpp::types::BoostProgressFunction, CURLOPT_PROGRESSFUNCTION
 	handle->option(CURLOPT_PROGRESSFUNCTION, Callbacks::ProgressCallback);
 	handle->option(CURLOPT_PROGRESSDATA, handle);
 	handle->setProgressFunctor(value);
-};
+}
 
 #endif
 
@@ -229,7 +229,7 @@ void OptionSetter<curlpp::types::WriteFunctionFunctor, CURLOPT_HEADERFUNCTION>
 	handle->option(CURLOPT_HEADERFUNCTION, Callbacks::HeaderCallback);
 	handle->option(CURLOPT_HEADERDATA, handle);
 	handle->setHeaderFunctor(value);
-};
+}
 
 
 #ifdef HAVE_BOOST
@@ -240,7 +240,7 @@ void OptionSetter<curlpp::types::BoostWriteFunction, CURLOPT_HEADERFUNCTION>
 	handle->option(CURLOPT_HEADERFUNCTION, Callbacks::HeaderCallback);
 	handle->option(CURLOPT_HEADERDATA, handle);
 	handle->setHeaderFunctor(value);
-};
+}
 
 #endif
 
@@ -251,7 +251,7 @@ void OptionSetter<curlpp::types::DebugFunctionFunctor, CURLOPT_DEBUGFUNCTION>
 	handle->option(CURLOPT_DEBUGFUNCTION, Callbacks::DebugCallback);
 	handle->option(CURLOPT_DEBUGDATA, handle);
 	handle->setDebugFunctor(value);
-};
+}
 
 
 #ifdef HAVE_BOOST
@@ -262,7 +262,7 @@ void OptionSetter<curlpp::types::BoostDebugFunction, CURLOPT_DEBUGFUNCTION>
 	handle->option(CURLOPT_DEBUGFUNCTION, Callbacks::DebugCallback);
 	handle->option(CURLOPT_DEBUGDATA, handle);
 	handle->setDebugFunctor(value);
-};
+}
 
 #endif
 
@@ -273,7 +273,7 @@ void OptionSetter<curlpp::types::SslCtxFunctionFunctor, CURLOPT_SSL_CTX_FUNCTION
 	handle->option(CURLOPT_SSL_CTX_FUNCTION, Callbacks::SslCtxCallback);
 	handle->option(CURLOPT_SSL_CTX_DATA, handle);
 	handle->setSslCtxFunctor(value);
-};
+}
 
 
 #ifdef HAVE_BOOST
@@ -284,7 +284,7 @@ void OptionSetter<curlpp::types::BoostSslCtxFunction, CURLOPT_SSL_CTX_FUNCTION>
 	handle->option(CURLOPT_SSL_CTX_FUNCTION, Callbacks::SslCtxCallback);
 	handle->option(CURLOPT_SSL_CTX_DATA, handle);
 	handle->setSslCtxFunctor(value);
-};
+}
 
 #endif
 


### PR DESCRIPTION
you use -DCURLPP_BUILD_SHARED_LIBS=ON or OFF to turn on or off the building of shared libs